### PR TITLE
Fix `bale.RemoveComponents` class bug

### DIFF
--- a/bale/components.py
+++ b/bale/components.py
@@ -156,4 +156,4 @@ class RemoveComponents:
     """This object shows a remove keyboard."""
 
     def to_dict(self) -> dict:
-        return {"inline_keyboard": None, "keyboard": None}
+        return {"keyboard": None}


### PR DESCRIPTION
### "Bale" web service when for that component as follows:
```py
{"inline_keyboard": None, "keyboard": None}
```
it is sent to the servers, nothing happens! And the keyboard is not deleted.

> This problem is because both inline_keyboard and keyboard parameters are given together.